### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Security Checks
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/8](https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/8)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the jobs in this workflow only perform read-only audit operations and do not need to write to the repository, the best practice is to set `contents: read` at the workflow level. This will apply to all jobs unless overridden. The change should be made at the top level of the `.github/workflows/security.yml` file, immediately after the `name` field and before the `on` field, or after the `on` field but before `jobs`. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
