### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/5](https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/5)

To fix the problem, you should add a `permissions` block to the workflow. The best practice is to set this at the root level of the workflow file, so it applies to all jobs unless overridden. Since none of the steps in the `build` job require write access to repository contents or other resources, the minimal required permission is `contents: read`. This change should be made at the top level of `.github/workflows/ci.yml`, immediately after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
