### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: PHPStan
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/2](https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/2)

To fix the problem, explicitly add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to the minimum required permissions. Since the workflow only needs to read the repository contents (to check out code and run static analysis), set `permissions: contents: read` at the workflow level (top-level, after the `name` and before `on`). This ensures all jobs in the workflow inherit these minimal permissions unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
