### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Release
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/7](https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code, builds a changelog, packages files, and uploads an artifact, it does not require write access to repository contents, issues, or pull requests. The minimal required permission is `contents: read`. This block should be added at the root level of the workflow (above `jobs:`) to apply to all jobs in the workflow. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
