### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-only.yml
+++ b/.github/workflows/lint-only.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint Only
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/6](https://github.com/Starisian-Technologies/sparxstar-starter/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to the least privilege required. Since the workflow only runs linting commands and does not need to write to the repository or interact with issues, pull requests, or other resources, the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `lint` job). The best practice is to set it at the workflow level unless a job needs different permissions. The change should be made at the top of the file, after the `name` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
