### PR TITLE
fix: composer.json valid JSON, align PSR-4, remove duplicate autoloader, safe phpstan/phpunit configs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,11 @@
     "composer/installers": "^2.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1",
     "phpstan/phpstan": "^1",
+    "phpunit/phpunit": "^10",
     "squizlabs/php_codesniffer": "^3",
-    "dealerdirect/phpcodesniffer-composer-installer": "^1"
+    "wp-coding-standards/wpcs": "^3"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,9 +3,7 @@ parameters:
   phpVersion: 80200
 
   paths:
-    - ./includes
     - ./src
-    - ./plugin-name.php
 
   autoload_files:
     - ./vendor/autoload.php
@@ -17,7 +15,6 @@ parameters:
     - vendor/*
     - node_modules/*
     - assets/*
-    - includes/lib/*
 
   checkMissingIterableValueType: false
   checkGenericClassInNonGenericObjectType: false

--- a/src/core/PluginCore.php
+++ b/src/core/PluginCore.php
@@ -3,7 +3,6 @@
 
 namespace Starisian\src\core;
 
-use Starisian\src\includes\PluginRules;
 
 if (!defined('ABSPATH')) {
     exit;

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,3 +1,3 @@
 <?php
 // PHPUnit bootstrap placeholder
-require_once __DIR__ . '/../../plugin-entry.php';
+require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
## Summary
- ensure composer.json is proper JSON, add WP coding standards, confirm PSR-4 mapping
- streamline phpstan and phpunit bootstrapping with vendor autoload
- drop unused PluginRules import

## Testing
- `composer update` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `composer dump-autoload` *(fails: Undefined array key "content-hash")*
- `vendor/bin/phpcs` *(fails: No such file or directory)*
- `vendor/bin/phpstan analyse -c phpstan.neon.dist --no-progress` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a515feab748332bfb4479cde912029