### PR TITLE
Refine core setup, CI, and docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+# Pull Request
+
+## Checklist
+- [ ] Tests pass (`composer run test:php` and `npm test`)
+- [ ] Linting passes (`composer run lint:php`)
+- [ ] Documentation updated
+
+## Summary
+Please provide a short summary of the changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,23 +3,29 @@ permissions:
 name: CI
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP
-        uses:   # uses: shivammathur/setup-php@20529878ed81ef8e78ddf08b480401e6101a850f
+        uses: shivammathur/setup-php@20529878ed81ef8e78ddf08b480401e6101a850f
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php-version }}
+          coverage: none
       - name: Install dependencies
         run: composer install --no-interaction
       - name: PHP Lint
-        run: composer lint:php
+        run: composer run lint:php
       - name: PHPStan
-        run: composer analyze:php
+        run: composer run analyze:php
       - name: PHPUnit
-        run: composer test:php
+        run: composer run test:php
       - name: Node tests
         run: npm test

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -1,5 +1,0 @@
-# Local Development
-
-- Requires PHP 8.2+, Composer, and Node LTS.
-- Run `composer install` and `npm install` (if using JS tooling).
-- Use `npm run lint` and `composer test:php` before committing.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,10 @@
 
 A template repository for building WordPress plugins that follow Starisian coding conventions and SPARXSTAR deployment needs.
 
-## Supported Stack
-- WordPress 6.4+
-- PHP 8.2+
-- Node.js (LTS) for optional asset tooling
-
-## Usage
+## Quick Start
 1. Clone this repo.
-2. Rename namespaces and plugin headers.
-3. Run `composer install` and `npm install` if using JS tooling.
-4. Implement features in `src/` and enqueue assets from `assets/`.
+2. Run `composer install`.
+3. Activate the plugin in WordPress.
+4. "Hello World."
 
-### When to Fork vs. Extend
-- **Fork** to create a new plugin.
-- **Extend** by importing as a subtree if you need to keep upstream changes.
-
-For architecture details see [ARCHITECTURE.md](ARCHITECTURE.md). Contribution guidelines live in [CONTRIBUTING.md](CONTRIBUTING.md).
+For detailed guides and notes, see the [docs/](docs/) directory.

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -1,0 +1,10 @@
+# First Contribution
+
+1. Fork the repository.
+2. Clone your fork and create a branch.
+3. Run `composer install` and `npm install`.
+4. Pick a "good first issue" or open a new one.
+5. Make your changes in `src/` or `tests/` as needed.
+6. Run `composer run lint:php` and `composer run test:php` before committing.
+7. Commit with a descriptive message and push to your fork.
+8. Open a pull request using the template and request review.

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -1,0 +1,37 @@
+# Local Development
+
+```yaml
+version: '3.9'
+services:
+  wordpress:
+    image: wordpress:6.4-php8.2
+    ports:
+      - "8000:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - ./:/var/www/html/wp-content/plugins/starisian-plugin
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db_data:/var/lib/mysql
+volumes:
+  db_data:
+```
+
+## Commands
+- `composer install`
+- `npm install`
+- `docker compose up -d`
+- Run unit tests: `composer run test:php`
+- Lint PHP: `composer run lint:php`
+- Analyze: `composer run analyze:php`
+- Build assets: `npm run build`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,18 @@
 # Documentation
 
-Extended guides and design notes live here.
+## Supported Stack
+- WordPress 6.4+
+- PHP 8.2+
+- Node.js (LTS) for optional asset tooling
+
+## Usage
+1. Clone this repo.
+2. Rename namespaces and plugin headers.
+3. Run `composer install` and `npm install` if using JS tooling.
+4. Implement features in `src/` and enqueue assets from `assets/`.
+
+### When to Fork vs. Extend
+- **Fork** to create a new plugin.
+- **Extend** by importing as a subtree if you need to keep upstream changes.
+
+For architecture details see [ARCHITECTURE.md](../ARCHITECTURE.md). Contribution guidelines live in [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,2 @@
+parameters:
+  ignoreErrors: []

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,8 @@ parameters:
   autoload_files:
     - ./vendor/autoload.php
 
+  baseline: phpstan-baseline.neon
+
   treatPhpDocTypesAsCertain: false
 
   excludePaths:

--- a/src/core/PluginCore.php
+++ b/src/core/PluginCore.php
@@ -36,8 +36,8 @@ final class PluginCore {
          */
         private function __construct() {
                 // Register core plugin hooks, rules, or services here.
-                if (class_exists(PluginRules::class, false)) {
-                        PluginRules::register_hooks();
+                if (class_exists('\\Starisian\\src\\includes\\PluginRules', false)) {
+                        \Starisian\src\includes\PluginRules::register_hooks();
                 }
         }
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,3 +1,5 @@
 <?php
-// PHPUnit bootstrap placeholder
-require_once __DIR__ . '/../../vendor/autoload.php';
+$autoload = __DIR__ . '/../../vendor/autoload.php';
+if (file_exists($autoload)) {
+    require $autoload;
+}


### PR DESCRIPTION
## Summary
- use fully qualified PluginRules lookup in core constructor
- streamline PHPUnit bootstrap and docs
- add PHP 8.2-8.4 CI matrix and contribution templates

## Testing
- `composer run lint:php` *(fails: phpcs: not found)*
- `composer run analyze:php` *(fails: phpstan: not found)*
- `composer run test:php` *(fails: phpunit: not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a51baced548332b77f186a90ec42d1